### PR TITLE
refactor: remove get_ prefix

### DIFF
--- a/examples/rate_limit_handling.py
+++ b/examples/rate_limit_handling.py
@@ -25,7 +25,7 @@ API_KEY = os.getenv("URLSCAN_API_KEY")
 def get_result_with_retry(client: urlscan.Client, uuid: str):
     """Get the result of a scan."""
     try:
-        return client.get_result(uuid)
+        return client.result(uuid)
     except urlscan.RateLimitError as exc:
         print(f"Rate limit error hit: {exc}")  # noqa: T201
         print(f"Wait {exc.rate_limit_reset_after} seconds before retrying...")  # noqa: T201

--- a/examples/screenshot_to_pil.py
+++ b/examples/screenshot_to_pil.py
@@ -28,7 +28,7 @@ def main(
     assert api_key
 
     with urlscan.Client(api_key) as client:
-        screenshot = client.get_screenshot(uuid)
+        screenshot = client.screenshot(uuid)
         image = Image.open(screenshot)
         image.show()
 

--- a/src/urlscan/client.py
+++ b/src/urlscan/client.py
@@ -161,7 +161,7 @@ class Client:
         res = ClientResponse(session.get(path, params=params))
         return self._response_to_str(res)
 
-    def get_result(self, uuid: str) -> dict:
+    def result(self, uuid: str) -> dict:
         """Get a result of a scan by UUID.
 
         Args:
@@ -175,7 +175,7 @@ class Client:
         """
         return self.get_json(f"/api/v1/result/{uuid}/")
 
-    def get_screenshot(self, uuid: str) -> BytesIO:
+    def screenshot(self, uuid: str) -> BytesIO:
         """Get a screenshot of a scan by UUID.
 
         Args:
@@ -193,7 +193,7 @@ class Client:
         bio.name = res.basename
         return bio
 
-    def get_dom(self, uuid: str) -> str:
+    def dom(self, uuid: str) -> str:
         """Get a DOM of a scan by UUID.
 
         Args:


### PR DESCRIPTION
Remove `get_` prefix from methods by following [this advice](https://github.com/urlscan/urlscan-python/pull/1#discussion_r2030569441).

(To be honest, I'm not sure whether they sound more natural than before)