### PR TITLE
refactor: control retry default via env (URLSCAN_RETRY)

### DIFF
--- a/docs/references/client.md
+++ b/docs/references/client.md
@@ -1,1 +1,18 @@
 ::: urlscan.Client
+
+## Retry
+
+This library provides an option for automatic retry based on [X-Rate-Limit-Reset-After HTTP header](https://urlscan.io/docs/api/#ratelimit) when a request gets `429 Too Many Requests` error.
+
+You can enable it by:
+
+```py
+with Client("<api_key>", retry=True) as client:
+    ...
+```
+
+or setting `URLSCAN_RETRY` environmental variable as `true`.
+
+```bash
+URLSCAN_RETRY=true python /path/to/script.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ select = [
   "FA",  # flake8-future-annotations
   "I",   # isort
   "N",   # pep8-naming
+  "PT",  # flake8-pytest-style
   "RET", # flake8-return
   "RUF", # Ruff-specific rules
   "SIM", # flake8-simplify

--- a/src/urlscan/client.py
+++ b/src/urlscan/client.py
@@ -10,11 +10,13 @@ from httpx._types import QueryParamTypes, RequestData, TimeoutTypes
 from ._version import version
 from .error import APIError, RateLimitError
 from .iterator import SearchIterator
+from .utils import cast_as_bool
 
 logger = logging.getLogger("urlscan-python")
 
 BASE_URL = os.environ.get("URLSCAN_BASE_URL", "https://urlscan.io")
 USER_AGENT = f"urlscan-py/{version}"
+RETRY: bool = cast_as_bool(os.environ.get("URLSCAN_RETRY")) or False
 
 
 def _compact(d: dict) -> dict:
@@ -74,7 +76,7 @@ class Client:
         timeout: TimeoutTypes = 60,
         proxy: str | None = None,
         verify: bool = True,
-        retry: bool = False,
+        retry: bool | None = None,
     ):
         """
         Args:
@@ -85,7 +87,7 @@ class Client:
             timeout (TimeoutTypes, optional): timeout configuration to use when sending request. Defaults to 60.
             proxy (str | None, optional): Proxy URL where all the traffic should be routed. Defaults to None.
             verify (bool, optional): Either `True` to use an SSL context with the default CA bundle, `False` to disable verification. Defaults to True.
-            retry (bool, optional): Whether to use automatic X-Rate-Limit-Reset-After HTTP header based retry. Defaults to False.
+            retry (bool | None, optional): Whether to use automatic X-Rate-Limit-Reset-After HTTP header based retry. Defaults to None.
         """
         self._api_key = api_key
         self._base_url = base_url
@@ -94,7 +96,7 @@ class Client:
         self._timeout = timeout
         self._proxy = proxy
         self._verify = verify
-        self._retry = retry
+        self._retry: bool = retry or RETRY
 
         self._session: httpx.Client | None = None
 

--- a/src/urlscan/utils.py
+++ b/src/urlscan/utils.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+
+def cast_as_bool(v: Any) -> bool | None:
+    if v is None:
+        return None
+
+    mapping = {"true": True, "1": True, "false": False, "0": False}
+    lowered = str(v).lower()
+    if lowered not in mapping:
+        raise ValueError(f"Not a valid bool: {v}")
+
+    return mapping[lowered]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from urlscan.utils import cast_as_bool
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("true", True),
+        ("1", True),
+        ("false", False),
+        ("0", False),
+        (None, None),
+        ("foo", ValueError),
+    ],
+)
+def test_cast_as_bool(value, expected):
+    if isinstance(expected, type) and issubclass(expected, Exception):
+        with pytest.raises(expected):
+            cast_as_bool(value)
+    else:
+        assert cast_as_bool(value) == expected


### PR DESCRIPTION
Make it possible to control a default value of `retry` via `URLSCAN_RETRY` env.

#4 looks strange and not user friendly to me and I think this approach is better. 
Setting the ENV variable if you want to use it by default with understanding a side effect. It sounds fair to me.  