### PR TITLE
docs: use magiclink

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.highlight
   - pymdownx.extra
+  - pymdownx.magiclink
 
 extra:
   generator: false


### PR DESCRIPTION
Use [MagicLink](https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/) to auto-link URLs inside docs.

For example:
![Screenshot 2025-04-12 at 11 48 15](https://github.com/user-attachments/assets/da4e2531-62e0-4b85-9708-af183e8511fd)
