### PR TITLE
refactor: enable stage_fixed in uv-sort and uv lock

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,9 +5,11 @@ pre-commit:
     uv-lock:
       glob: "pyproject.toml"
       run: uv lock
+      stage_fixed: true
     uv-sort:
       glob: "pyproject.toml"
       run: uv run uv-sort
+      stage_fixed: true
     ruff:
       glob: "*.py"
       run: uv run ruff check --fix {staged_files}


### PR DESCRIPTION
Enable [stage_fixed](https://lefthook.dev/configuration/stage_fixed.html) in `uv-sort` and `uv lock` to automatically stage modified files (`pyproject.toml` and `uv.lock` in this case).