### PR TITLE
fix: fix B008 warnings

### DIFF
--- a/examples/screenshot_to_pil.py
+++ b/examples/screenshot_to_pil.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #    "pillow",
+#    "python-dotenv",
 #    "typer",
 #    "urlscan-python",
 # ]
@@ -11,18 +12,25 @@
 # usage: uv run examples/screenshot_to_pil.py <UUID>
 
 import os
+from typing import Annotated
 
 import typer
+from dotenv import load_dotenv
 from PIL import Image
 
 import urlscan
+
+load_dotenv()
 
 API_KEY = os.getenv("URLSCAN_API_KEY")
 
 
 def main(
-    uuid: str = typer.Argument(..., help="Result UUID"),
-    api_key: str | None = typer.Option(None, help="Your API key"),
+    uuid: Annotated[str, typer.Argument(help="Result UUID")],
+    api_key: Annotated[
+        str | None,
+        typer.Option(help="Your API key, defaults to URLSCAN_API_KEY env"),
+    ] = None,
 ) -> None:
     api_key = api_key or API_KEY
     assert api_key

--- a/examples/search_and_download_screenshots.py
+++ b/examples/search_and_download_screenshots.py
@@ -1,6 +1,7 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
+#    "python-dotenv",
 #    "typer",
 #    "urlscan-python",
 # ]
@@ -12,24 +13,31 @@
 
 import os
 from pathlib import Path
+from typing import Annotated
 
 import typer
+from dotenv import load_dotenv
 
 import urlscan
+
+load_dotenv()
 
 API_KEY = os.getenv("URLSCAN_API_KEY")
 
 
 def main(
-    query: str = typer.Argument(..., help="Search query"),
-    limit: int = typer.Option(10, help="Limit of search results"),
-    api_key: str | None = typer.Option(None, help="Your API key"),
-    dest: Path = typer.Option(  # noqa: B008
-        Path("/tmp"), help="Destination directory to download screenshots"
-    ),
+    query: Annotated[str, typer.Argument(help="Search query")],
+    api_key: Annotated[
+        str | None,
+        typer.Option(help="Your API key. Defaults to URLSCAN_API_KEY env."),
+    ] = None,
+    limit: Annotated[int, typer.Option(help="Limit of search results")] = 10,
+    dest: Annotated[
+        Path, typer.Option(help="Destination directory to download screenshots")
+    ] = Path("/tmp"),
 ) -> None:
     api_key = api_key or API_KEY
-    assert api_key
+    assert api_key, "API key is required"
 
     with urlscan.Client(api_key) as client:
         for result in client.search(query, limit=limit):

--- a/examples/search_to_dataframe.py
+++ b/examples/search_to_dataframe.py
@@ -3,6 +3,7 @@
 # dependencies = [
 #    "itables",
 #    "pandas",
+#    "python-dotenv",
 #    "typer",
 #    "urlscan-python",
 # ]
@@ -15,24 +16,30 @@
 import os
 import webbrowser
 from pathlib import Path
+from typing import Annotated
 
 import itables
 import pandas as pd
 import typer
+from dotenv import load_dotenv
 
 import urlscan
+
+load_dotenv()
 
 API_KEY = os.getenv("URLSCAN_API_KEY")
 
 
 def main(
-    query: str = typer.Argument(..., help="Search query"),
-    limit: int = typer.Option(10, help="Limit of search results"),
-    api_key: str | None = typer.Option(None, help="Your API key"),
-    path: Path = typer.Option(  # noqa: B008
-        Path("report.html"),
-        help="Path to save a dataframe as an HTML file",
-    ),
+    query: Annotated[str, typer.Argument(help="Search query")],
+    api_key: Annotated[
+        str | None,
+        typer.Option(help="Your API key, defaults to URLSCAN_API_KEY env"),
+    ] = None,
+    limit: Annotated[int, typer.Option(help="Limit of search results")] = 100,
+    path: Annotated[
+        Path, typer.Option(help="Path to save a dataframe as an HTML file")
+    ] = Path("report.html"),
 ) -> None:
     api_key = api_key or API_KEY
     assert api_key


### PR DESCRIPTION
Fix [B008](https://docs.astral.sh/ruff/rules/function-call-in-default-argument/) warnings by using [Annotated](https://docs.python.org/3/library/typing.html#typing.Annotated). (Note: [this my comment](https://github.com/urlscan/urlscan-python/pull/17#discussion_r2063405366) is wrong.)

Also this PR introduces [python-dotenv](https://github.com/theskumar/python-dotenv) to load a key via `.env`.
