### PR TITLE
fix: fix iteration error

### DIFF
--- a/src/urlscan/iterator.py
+++ b/src/urlscan/iterator.py
@@ -75,6 +75,8 @@ class SearchIterator:
             self._total = self._total or total
             if self._total != MAX_TOTAL:
                 self._has_more = self._total > (self._count + len(self._results))
+            else:
+                self._has_more = len(self._results) >= self._size
 
             if len(self._results) > 0:
                 last_result = self._results[-1]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -150,7 +150,7 @@ def test_search_with_iteration_over_10000_results(
 
     got = list(client.search(q, size=10000))
     assert len(got) == 10001
-    assert len(httpserver.log) == 3
+    assert len(httpserver.log) == 2
 
 
 def test_retry(client: Client, httpserver: HTTPServer):


### PR DESCRIPTION
Fix iteration error.

Change the behavior based on `total`:

- `total == 10_000`: use a number of results for iteration (stop iterating if `results` is empty)
- `total < 10_000`: use `total` and an internal counter + a number of results for iteration (do iteration until `total` > counter + a number of results)