### PR TITLE
chore: add 3.14 classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
A follow up PR for #26 (I forgot to update `project.classifiers` to include 3.14) 