### PR TITLE
feat: add count method in iterator

### DIFF
--- a/src/urlscan/iterator.py
+++ b/src/urlscan/iterator.py
@@ -138,12 +138,10 @@ class SearchIterator(BaseIterator):
         """
         data = self._client.get_json(
             self._path,
-            params=_compact(
-                {
-                    "q": self._q,
-                    "size": 0,
-                }
-            ),
+            params={
+                "q": self._q,
+                "size": 0,
+            },
         )
         _, total = self._parse_response(data)
         return total

--- a/src/urlscan/iterator.py
+++ b/src/urlscan/iterator.py
@@ -123,3 +123,27 @@ class SearchIterator(BaseIterator):
         result = self._results.pop(0)
         self._count += 1
         return result
+
+    def count(self) -> int:
+        """Count the total number of matching results without retrieving them.
+
+        Examples:
+            >>> from urlscan import Client
+            >>> with Client("<your_api_key>") as client:
+            ...     client.search("page.domain:example.com").count()
+
+        Returns:
+            int: Total number of matching results.
+
+        """
+        data = self._client.get_json(
+            self._path,
+            params=_compact(
+                {
+                    "q": self._q,
+                    "size": 0,
+                }
+            ),
+        )
+        _, total = self._parse_response(data)
+        return total

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -64,6 +64,21 @@ def test_search(client: Client, httpserver: HTTPServer):
     assert len(httpserver.log) == 1
 
 
+def test_search_count(client: Client, httpserver: HTTPServer):
+    q = "foo"
+
+    httpserver.expect_request(
+        "/api/v1/search/",
+        method="GET",
+        query_string={"q": q, "size": "0"},
+    ).respond_with_json({"results": [], "has_more": False, "total": 42})
+
+    it = client.search(q)
+    got = it.count()
+    assert got == 42
+    assert len(httpserver.log) == 1
+
+
 def test_search_with_iteration_within_10000_results(
     client: Client, httpserver: HTTPServer
 ):


### PR DESCRIPTION
Similar to https://github.com/urlscan/urlscan-cli/pull/136.

I noticed that it's a bit difficult to strange to do search counting with the current implementation:

```py
with Client(api_key=API_KEY) as client:
    it = client.search("page.domain:example.com", size=0)
    # run iterator to get the total count
    for _ in it:
        pass
    print(it._total)
```

This PR adds `count` method to simplify it:

```py
with Client(api_key=API_KEY) as client:
    it = client.search("page.domain:example.com")
    print(it.count())
```