### PR TITLE
PEP517 build dependency pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,18 @@ docs = [
 
 [tool.uv]
 default-groups = ["dev", "docs"]
+build-constraint-dependencies = [
+  "dunamai==1.26.2",
+  "hatchling==1.32.0",
+  "jinja2==3.1.6",
+  "markupsafe==3.0.3",
+  "packaging==26.3",
+  "pathspec==1.1.1",
+  "pluggy==1.6.0",
+  "tomlkit==0.15.1",
+  "trove-classifiers==2026.6.1.19",
+  "uv-dynamic-versioning==0.14.0"
+]
 
 [tool.uv.pip]
 # ref. https://github.com/lirantal/pypi-security-best-practices#1-prefer-binary-only-installs

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,20 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <4.0"
 
+[manifest]
+build-constraints = [
+    { name = "dunamai", specifier = "==1.26.2" },
+    { name = "hatchling", specifier = "==1.32.0" },
+    { name = "jinja2", specifier = "==3.1.6" },
+    { name = "markupsafe", specifier = "==3.0.3" },
+    { name = "packaging", specifier = "==26.3" },
+    { name = "pathspec", specifier = "==1.1.1" },
+    { name = "pluggy", specifier = "==1.6.0" },
+    { name = "tomlkit", specifier = "==0.15.1" },
+    { name = "trove-classifiers", specifier = "==2026.6.1.19" },
+    { name = "uv-dynamic-versioning", specifier = "==0.14.0" },
+]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -206,7 +220,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
Pin build dependencies to prevent installing something unknown in the build phase (same as https://github.com/modelcontextprotocol/python-sdk/pull/2547).

