### PR TITLE
Deprecation warning

### DIFF
--- a/src/urlscan/client.py
+++ b/src/urlscan/client.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import time
+import warnings
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Any, BinaryIO, Literal, TypedDict, cast
@@ -453,6 +454,11 @@ class BaseClient:
             raise error
 
         return res.content
+
+    def _warn_deprecation(self, message: str, stacklevel: int) -> None:
+        """Warn about deprecated features."""
+        # ref. https://sethmlarson.dev/deprecations-via-warnings-dont-work-for-python-libraries
+        warnings.warn(message, category=FutureWarning, stacklevel=stacklevel)
 
 
 class Client(BaseClient):

--- a/src/urlscan/pro/livescan.py
+++ b/src/urlscan/pro/livescan.py
@@ -1,10 +1,13 @@
 """Live scanning API client module."""
 
+import warnings
 from typing import Any
 
 from urlscan.client import BaseClient, _compact
 from urlscan.types import LiveScanResourceType, VisibilityType
 from urlscan.utils import _merge
+
+DEPRECATED_FEATURES: set[str] = {"stealth"}
 
 
 class LiveScan(BaseClient):
@@ -21,6 +24,47 @@ class LiveScan(BaseClient):
 
         """
         return self.get_json("/api/v1/livescan/scanners/")
+
+    def _build_scan_payload(
+        self,
+        url: str,
+        visibility: VisibilityType | None = None,
+        page_timeout: int | None = None,
+        capture_delay: int | None = None,
+        extra_headers: dict[str, str] | None = None,
+        enable_features: list[str] | None = None,
+        disable_features: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build the payload for a scan request."""
+        task: dict[str, Any] = _compact(
+            {
+                "url": url,
+                "visibility": visibility,
+            }
+        )
+        # check for deprecated features
+        for feature in disable_features or []:
+            if feature in DEPRECATED_FEATURES:
+                warnings.warn(
+                    f"The feature '{feature}' is deprecated.",
+                    # ref. https://sethmlarson.dev/deprecations-via-warnings-dont-work-for-python-libraries
+                    category=FutureWarning,
+                    stacklevel=3,
+                )
+        scanner: dict[str, Any] = _compact(
+            _merge(
+                {
+                    "pageTimeout": page_timeout,
+                    "captureDelay": capture_delay,
+                    "extraHeaders": extra_headers,
+                    "enableFeatures": enable_features,
+                    "disableFeatures": disable_features,
+                },
+                kwargs,
+            )
+        )
+        return {"task": task, "scanner": scanner}
 
     def task(
         self,
@@ -57,26 +101,16 @@ class LiveScan(BaseClient):
             https://docs.urlscan.io/apis/urlscan-openapi/live-scanning/livescantask
 
         """
-        task: dict[str, Any] = _compact(
-            {
-                "url": url,
-                "visibility": visibility,
-            }
+        data = self._build_scan_payload(
+            url,
+            visibility=visibility,
+            page_timeout=page_timeout,
+            capture_delay=capture_delay,
+            extra_headers=extra_headers,
+            enable_features=enable_features,
+            disable_features=disable_features,
+            **kwargs,
         )
-        scanner: dict[str, Any] = _compact(
-            _merge(
-                {
-                    "pageTimeout": page_timeout,
-                    "captureDelay": capture_delay,
-                    "extraHeaders": extra_headers,
-                    "enableFeatures": enable_features,
-                    "disableFeatures": disable_features,
-                },
-                kwargs,
-            )
-        )
-        data: dict[str, Any] = {"task": task, "scanner": scanner}
-
         res = self._post(f"/api/v1/livescan/{scanner_id}/task/", json=data)
         return self._response_to_json(res)
 
@@ -113,26 +147,16 @@ class LiveScan(BaseClient):
             https://docs.urlscan.io/apis/urlscan-openapi/live-scanning/livescanscan
 
         """
-        task: dict[str, Any] = _compact(
-            {
-                "url": url,
-                "visibility": visibility,
-            }
+        data = self._build_scan_payload(
+            url,
+            visibility=visibility,
+            page_timeout=page_timeout,
+            capture_delay=capture_delay,
+            extra_headers=extra_headers,
+            enable_features=enable_features,
+            disable_features=disable_features,
+            **kwargs,
         )
-        scanner: dict[str, Any] = _compact(
-            _merge(
-                {
-                    "pageTimeout": page_timeout,
-                    "captureDelay": capture_delay,
-                    "extraHeaders": extra_headers,
-                    "enableFeatures": enable_features,
-                    "disableFeatures": disable_features,
-                },
-                kwargs,
-            )
-        )
-        data: dict[str, Any] = {"task": task, "scanner": scanner}
-
         res = self._post(f"/api/v1/livescan/{scanner_id}/scan/", json=data)
         return self._response_to_json(res)
 

--- a/src/urlscan/pro/livescan.py
+++ b/src/urlscan/pro/livescan.py
@@ -1,6 +1,5 @@
 """Live scanning API client module."""
 
-import warnings
 from typing import Any
 
 from urlscan.client import BaseClient, _compact
@@ -46,11 +45,8 @@ class LiveScan(BaseClient):
         # check for deprecated features
         for feature in disable_features or []:
             if feature in DEPRECATED_FEATURES:
-                warnings.warn(
-                    f"The feature '{feature}' is deprecated.",
-                    # ref. https://sethmlarson.dev/deprecations-via-warnings-dont-work-for-python-libraries
-                    category=FutureWarning,
-                    stacklevel=3,
+                self._warn_deprecation(
+                    f"The feature '{feature}' is deprecated.", stacklevel=4
                 )
         scanner: dict[str, Any] = _compact(
             _merge(


### PR DESCRIPTION
Make it possible to warn deprecation via `BaseClient#_warn_deprecation` method & use it when `stealth` is used in livescan methods.

```py
from urlscan.pro import Pro

with Pro("...") as client:
    got = client.livescan.task(
        url="https://www.example.com",
        visibility="private",
        scanner_id="jp01",
        disable_features=["stealth"],
    )
```

```bash
$ python test.py
/path/to/test.py:4: FutureWarning: The feature 'stealth' is deprecated.
  got = client.livescan.task(
```