### PR TITLE
docs: support GitHub admotions in MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ plugins:
       python:
         options:
           show_root_heading: true
+  gh-admonitions:
   include-markdown:
   mike:
     canonical_version: latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
 ]
 docs = [
   "mike>=2.1.4",
+  "mkdocs-github-admonitions-plugin>=0.1.1",
   "mkdocs-include-markdown-plugin>=7.2.2",
   "mkdocs-material>=9.7.6",
   "mkdocs>=1.6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -220,7 +220,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -678,6 +678,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-github-admonitions-plugin"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/62/37f2080af26ec1d569bb21eb2a4d54f5ea54d36a92938abbbc37c6ab671b/mkdocs_github_admonitions_plugin-0.1.1.tar.gz", hash = "sha256:7f81520a0681b9955952d73b21ce99b923921830b6b6d1ace9b3fb95cd1fb61f", size = 5151, upload-time = "2025-06-02T09:45:12.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/a3/8cfd5d9a651612b0d2a15176341b040d43d27b063e17684cb353ec7ce789/mkdocs_github_admonitions_plugin-0.1.1-py3-none-any.whl", hash = "sha256:824dc821764171943c1043c88218d4af0329693870ba9be657f890d484a0aa85", size = 5493, upload-time = "2025-06-02T09:45:11.068Z" },
 ]
 
 [[package]]
@@ -1460,6 +1472,7 @@ dev = [
 docs = [
     { name = "mike" },
     { name = "mkdocs" },
+    { name = "mkdocs-github-admonitions-plugin" },
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -1489,6 +1502,7 @@ dev = [
 docs = [
     { name = "mike", specifier = ">=2.1.4" },
     { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-github-admonitions-plugin", specifier = ">=0.1.1" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.2.2" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },


### PR DESCRIPTION
I overlooked this small glitch in [the documentation](https://urlscan.github.io/urlscan-python/latest/):

<img width="789" height="302" alt="Screenshot 2026-09-03 at 16 43 03" src="https://github.com/user-attachments/assets/0474e349-fd7b-407c-ae71-3d4195569bd4" />

The documentation is based on MkDocs and it co-uses README.md & it uses [GitHub admotions](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts). It's incompatible in MkDocs.

Adding [mkdocs-github-admonitions-plugin](https://github.com/PGijsbers/admonitions) fixes it:

<img width="734" height="276" alt="Screenshot 2026-09-03 at 16 41 47" src="https://github.com/user-attachments/assets/a606b565-40d9-4d1b-8f17-feaf37d560b4" />
