### PR TITLE
fix: remove --force from "mike deploy"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,5 +44,5 @@ jobs:
             fi
           fi
           VERSION=$(uv run python scripts/convert_to_pep440_version.py "$VERSION")
-          uv run mike deploy "$VERSION" latest --update-aliases --push --force
+          uv run mike deploy "$VERSION" latest --update-aliases --push
           uv run mike set-default latest --push


### PR DESCRIPTION
A follow up PR for #89.

I overlooked that [--force` is deprecated](https://github.com/jimporter/mike/blob/master/CHANGES.md#breaking-changes). Also Mike does:

>  When deploying a particular version, previously-deployed docs for that version are erased and overwritten, but docs for other versions remain untouched.
> --- https://github.com/jimporter/mike#how-it-works

So redeploy works without having additional options. 

