### PR TITLE
chore: remove method for /api/v1/userAgents

### DIFF
--- a/src/urlscan/client.py
+++ b/src/urlscan/client.py
@@ -818,18 +818,6 @@ class Client(BaseClient):
         """
         return self.get_json("/api/v1/availableCountries")
 
-    def get_user_agents(self) -> dict:
-        """Get grouped user agents to use with the Scan API.
-
-        Returns:
-            dict: Available user agents.
-
-        Reference:
-            https://docs.urlscan.io/apis/urlscan-openapi/scanning/getuseragents
-
-        """
-        return self.get_json("/api/v1/userAgents")
-
     def get_quotas(self) -> dict:
         """Get available and used API quotas.
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -42,13 +42,6 @@ def test_get_available_countries(client: Client):
 
 
 @pytest.mark.integration
-def test_get_user_agents(client: Client):
-    user_agents = client.get_user_agents()
-    assert isinstance(user_agents, dict)
-    assert len(user_agents) > 0
-
-
-@pytest.mark.integration
 def test_get_response(client: Client):
     # hash of an empty content/string
     res = client.get_response(

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -375,32 +375,6 @@ def test_get_available_countries(client: Client, httpserver: HTTPServer):
     assert got == data
 
 
-def test_get_user_agents(client: Client, httpserver: HTTPServer):
-    data = {
-        "userAgents": [
-            {
-                "group": "Chrome",
-                "useragents": [
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36"
-                ],
-            },
-            {
-                "group": "iOS",
-                "useragents": [
-                    "Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1"
-                ],
-            },
-        ]
-    }
-    httpserver.expect_request(
-        "/api/v1/userAgents",
-        method="GET",
-    ).respond_with_json(data)
-
-    got = client.get_user_agents()
-    assert got == data
-
-
 def test_get_quotas(client: Client, httpserver: HTTPServer):
     data = {
         "scope": "team",


### PR DESCRIPTION
Remove method for `/api/v1/userAgents` by reflecting internal discussion 